### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ Bun automatically releases a canary build on every commit to `main`. To upgrade 
 ```sh
 bun upgrade --canary
 ```
+for older CPU Architecture you may have CPU Architecture issue fix it with 
+(intel)
+```1
+wget  https://downloadmirror.intel.com/784319/sde-external-9.24.0-2023-07-13-lin.tar.xz -O /tmp/intel-sde.tar.xz
+cd /tmp
+tar -xf intel-sde.tar.xz
+cd sde-external*
+mkdir /usr/local/bin -p
+cp sde64 /usr/local/bin/sde
+cp -r intel64 /usr/local/bin/
+cp -r misc /usr/local/bin/
+
+```
+```2
+echo "alias bun='sde -chip-check-disable -- bun'" >> ~/.bashrc
+
+```
 
 [View canary build](https://github.com/oven-sh/bun/releases/tag/canary)
 


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
